### PR TITLE
Pass all required args to function

### DIFF
--- a/src/org/jetbrains/idea/project/filetemplate/PerProjectTemplateManager.java
+++ b/src/org/jetbrains/idea/project/filetemplate/PerProjectTemplateManager.java
@@ -147,7 +147,7 @@ public class PerProjectTemplateManager extends AbstractProjectComponent implemen
 
         for (FileTemplate template : allTemplates) {
             try {
-                String[] variables = FileTemplateUtil.calculateAttributes(template.getText(), new Properties(), true);
+                String[] variables = FileTemplateUtil.calculateAttributes(template.getText(), new Properties(), true, project);
                 result.addAll(Arrays.asList(variables));
             } catch (ParseException e) {
                 logger.warn("Parsing exception", e);


### PR DESCRIPTION
This is apparently is a result of https://github.com/JetBrains/intellij-community/commit/0ec276863c865184a44fbcacd838b6ed829f2e09#diff-da751a166c55451a00fb447791ba3b9eL130. The problem is that the signature of that function was changed to expect a fourth parameter, which should be the `Project` object. Fortunately we have one handy in the `project` attribute.

Note that this is my first ever foray into Java from a PHP world, and that I haven't tested this fix yet.

Fixes #12, #13, #14
